### PR TITLE
Tree-sitter support for menhir

### DIFF
--- a/grammars/tree-sitter-menhir.cson
+++ b/grammars/tree-sitter-menhir.cson
@@ -82,6 +82,8 @@ scopes:
   'attribute > "]"': 'punctuation.section.embedded'
 
   'old_rule > symbol': 'entity.name.function'
+  # TODO: add an alias where function applications occur in the parser
+  # 'application:nth-child(0)': 'entity.name.function'
   'new_rule > lid': 'entity.name.function'
   'uid': 'entity.name.type.variant.ocaml'
   'lid': [

--- a/grammars/tree-sitter-menhir.cson
+++ b/grammars/tree-sitter-menhir.cson
@@ -53,8 +53,9 @@ scopes:
   '"%start"': 'keyword.operator'
   '"%attribute"': 'keyword.operator'
   '"%on_error_reduce"': 'keyword.operator'
-  '"%public"': 'keyword.other.special-method'
-  '"%inline"': 'keyword.other.special-method'
+
+  '"%public"': 'storage.modifier'
+  '"%inline"': 'storage.modifier'
 
   '"let"': 'storage.type.function'
   '":="': 'keyword.control'
@@ -83,6 +84,24 @@ scopes:
   'old_rule > symbol': 'entity.name.function'
   'new_rule > lid': 'entity.name.function'
   'uid': 'entity.name.type.variant.ocaml'
-  'lid':
-    match: /^(endrule|midrule|option|ioption|boption|loption|pair|separated_pair|preceded|terminated|delimited|list|nonempty_list|separated_list|separated_nonempty_list|rev|flatten|append)$/
-    scopes: 'support.function'
+  'lid': [
+    {exact: 'delimited', scopes: 'support.function'}
+    {exact: 'endrule', scopes: 'support.function'}
+    {exact: 'midrule', scopes: 'support.function'}
+    {exact: 'option', scopes: 'support.function'}
+    {exact: 'ioption', scopes: 'support.function'}
+    {exact: 'boption', scopes: 'support.function'}
+    {exact: 'loption', scopes: 'support.function'}
+    {exact: 'pair', scopes: 'support.function'}
+    {exact: 'separated_pair', scopes: 'support.function'}
+    {exact: 'preceded', scopes: 'support.function'}
+    {exact: 'terminated', scopes: 'support.function'}
+    {exact: 'list', scopes: 'support.function'}
+    {exact: 'nonempty_list', scopes: 'support.function'}
+    {exact: 'separated_list', scopes: 'support.function'}
+    {exact: 'separated_nonempty_list', scopes: 'support.function'}
+    {exact: 'rev', scopes: 'support.function'}
+    {exact: 'flatten', scopes: 'support.function'}
+    {exact: 'append', scopes: 'support.function'}
+    'entity.name'
+  ]

--- a/grammars/tree-sitter-menhir.cson
+++ b/grammars/tree-sitter-menhir.cson
@@ -1,0 +1,88 @@
+name: 'Menhir'
+scopeName: 'source.menhir'
+type: 'tree-sitter'
+parser: 'tree-sitter-menhir'
+
+fileTypes: [
+  'mly'
+]
+
+folds: [
+  {
+    type: [
+      'ocaml_comment'
+      'comment'
+    ]
+  }
+  {
+    type: [
+      'header'
+      'action'
+      'type'
+      'attribute'
+    ]
+    start: {index: 0}
+    end: {index: -1}
+  }
+  {
+    type: 'new_rule'
+    start: {type: 'equality_symbol'}
+  }
+  {
+    type: 'old_rule'
+    start: {type: '":"'}
+  }
+]
+
+comments:
+  start: '// '
+
+scopes:
+  'source_file': 'source.menhir'
+
+  'comment': 'comment.block'
+  'ocaml_comment': 'comment.block'
+  'line_comment': 'comment.line'
+
+  '"%parameter"': 'keyword.operator'
+  '"%token"': 'keyword.operator'
+  '"%left"': 'keyword.operator'
+  '"%right"': 'keyword.operator'
+  '"%nonassoc"': 'keyword.operator'
+  '"%type"': 'keyword.operator'
+  '"%start"': 'keyword.operator'
+  '"%attribute"': 'keyword.operator'
+  '"%on_error_reduce"': 'keyword.operator'
+  '"%public"': 'keyword.other.special-method'
+  '"%inline"': 'keyword.other.special-method'
+
+  '"let"': 'storage.type.function'
+  '":="': 'keyword.control'
+  '"=="': 'keyword.control'
+  '"~"': 'keyword.operator'
+
+  '"="': 'keyword.operator'
+  '"?"': 'keyword.operator'
+  '"*"': 'keyword.operator'
+  '"+"': 'keyword.operator'
+  '"|"': 'keyword.control'
+  '":"': 'keyword.control'
+  '";"': 'keyword.control'
+  '"%%"': 'keyword.control'
+  '"%%"': 'keyword.control'
+  '","': 'punctuation.definition.separator'
+  '"<"': 'punctuation.section.embedded'
+  '">"': 'punctuation.section.embedded'
+  '"{"': 'punctuation.section.embedded'
+  '"}"': 'punctuation.section.embedded'
+  '"%{"': 'punctuation.section.embedded'
+  '"%}"': 'punctuation.section.embedded'
+  '"[@"': 'punctuation.section.embedded'
+  'attribute > "]"': 'punctuation.section.embedded'
+
+  'old_rule > symbol': 'entity.name.function'
+  'new_rule > lid': 'entity.name.function'
+  'uid': 'entity.name.type.variant.ocaml'
+  'lid':
+    match: /^(endrule|midrule|option|ioption|boption|loption|pair|separated_pair|preceded|terminated|delimited|list|nonempty_list|separated_list|separated_nonempty_list|rev|flatten|append)$/
+    scopes: 'support.function'

--- a/main.js
+++ b/main.js
@@ -1,6 +1,22 @@
 exports.activate = function() {
   if (!atom.grammars.addInjectionPoint) return
 
+  atom.grammars.addInjectionPoint('source.menhir', {
+    type: 'ocaml',
+
+    language: (node) => 'ocaml',
+
+    content: (node) => node
+  })
+
+  atom.grammars.addInjectionPoint('source.menhir', {
+    type: 'ocaml_type',
+
+    language: (node) => 'ocaml',
+
+    content: (node) => node
+  })
+
   atom.grammars.addInjectionPoint('source.ocamllex', {
     type: 'lexer_definition',
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,21 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
       "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
     },
+    "tree-sitter-menhir": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-menhir/-/tree-sitter-menhir-0.1.2.tgz",
+      "integrity": "sha512-DOF/niTUW5h/D9ICncbn3HqGrPHNShxbvzWekNMz+pemHkvSIAL+aJIvS9x4NetQTLy1jTVIEI43lEYtaG8V2A==",
+      "requires": {
+        "nan": "^2.12.1"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
+          "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA=="
+        }
+      }
+    },
     "tree-sitter-ocaml": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/tree-sitter-ocaml/-/tree-sitter-ocaml-0.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "tree-sitter-ocaml": "^0.13.1",
-    "tree-sitter-ocamllex": "^0.13.0"
+    "tree-sitter-ocamllex": "^0.13.0",
+    "tree-sitter-menhir": "^0.1.2"
   },
   "devDependencies": {
     "atom-grammar-test": "^0.6.3"


### PR DESCRIPTION
This patch adds tree-sitter support for menhir files using [tree-sitter-menhir](https://github.com/Kerl13/tree-sitter-menhir).

Are you interested in integrating this into language-ocaml-fix ?

Any suggestions of improvement are welcome :slightly_smiling_face: 